### PR TITLE
chore: add .worktrees to gitignore and format routeTree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ temp
 
 # drafts
 drafts
+
+# Worktrees
+.worktrees


### PR DESCRIPTION
## Summary
- Add `.worktrees` directory to `.gitignore` to exclude git worktree directories
- Format `routeTree.gen.ts` with single quotes for consistency

## Test plan
- [ ] Verify `.worktrees` is properly ignored by git
- [ ] Run `bun check` to confirm formatting is consistent